### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@ class ProductsController < ApplicationController
   before_action :move_to_index, except: :index
 
   def index
+    @products = Product.all
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :move_to_index, except: :index
 
   def index
-    @products = Product.all
+    @products = Product.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -125,19 +125,17 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @products != blank? %>
         <% @products.each do |product| %>
           <li class='list'>
               <%= link_to "#" do %> 
                 <div class='item-img-content'>
                   <%= image_tag product.image, class: "item-img" if product.image.attached? %>
-                  <%# 商品が売れていればsold outを表示しましょう %>
+                  <%# 商品が売れていればsold outを表示しましょう(商品購入機能未実装の為残し) %>
                   <%# <div class='sold-out'>
                     <span>Sold Out!!</span>
                   </div> %>
-                  <%# //商品が売れていればsold outを表示しましょう %>
+                  <%# //商品が売れていればsold outを表示しましょう(商品購入機能未実装の為残し) %>
                 </div>
                 <div class='item-info'>
                   <h3 class='item-name'>
@@ -154,10 +152,8 @@
               <% end %>
           </li>
         <% end %>
-        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% else %>
         <%# 商品がない場合のダミー %>
-        <%# 商品がある場合は表示されないようにしましょう %>
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -175,8 +171,6 @@
             </div>
           <% end %>
         </li>
-        <%# //商品がある場合は表示されないようにしましょう %>
-        <%# /商品がない場合のダミー %>
       <% end %>
     </ul>
   </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -144,7 +144,7 @@
                     <%= product.name %>
                   </h3>
                   <div class='item-price'>
-                    <span><%= "販売価格" %>円<br>(税込み)</span>
+                    <span><%= product.price %>円<br>(税込み)</span>
                     <div class='star-btn'>
                       <%= image_tag "star.png", class:"star-icon" %>
                       <span class='star-count'>0</span>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -134,9 +134,9 @@
                 <div class='item-img-content'>
                   <%= image_tag product.image, class: "item-img" if product.image.attached? %>
                   <%# 商品が売れていればsold outを表示しましょう %>
-                  <div class='sold-out'>
+                  <%# <div class='sold-out'>
                     <span>Sold Out!!</span>
-                  </div>
+                  </div> %>
                   <%# //商品が売れていればsold outを表示しましょう %>
                 </div>
                 <div class='item-info'>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,30 +128,32 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @products != blank? %>
-        <li class='list'>
-            <%= link_to "#" do %> 
-              <div class='item-img-content'>
-                <%= image_tag "item-sample.png", class: "item-img" %>
-                <%# 商品が売れていればsold outを表示しましょう %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
+        <% @products.each do |product| %>
+          <li class='list'>
+              <%= link_to "#" do %> 
+                <div class='item-img-content'>
+                  <%= image_tag "item-sample.png", class: "item-img" %>
+                  <%# 商品が売れていればsold outを表示しましょう %>
+                  <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                  </div>
+                  <%# //商品が売れていればsold outを表示しましょう %>
                 </div>
-                <%# //商品が売れていればsold outを表示しましょう %>
-              </div>
-              <div class='item-info'>
-                <h3 class='item-name'>
-                  <%= "商品名" %>
-                </h3>
-                <div class='item-price'>
-                  <span><%= "販売価格" %>円<br>(税込み)</span>
-                  <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                    <span class='star-count'>0</span>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%=  "商品名" %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= "販売価格" %>円<br>(税込み)</span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-          <% end %> 
-        </li>
+              <% end %>
+          </li>
+        <% end %>
         <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% else %>
         <%# 商品がない場合のダミー %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -132,7 +132,7 @@
           <li class='list'>
               <%= link_to "#" do %> 
                 <div class='item-img-content'>
-                  <%= image_tag "item-sample.png", class: "item-img" %>
+                  <%= image_tag product.image, class: "item-img" if product.image.attached? %>
                   <%# 商品が売れていればsold outを表示しましょう %>
                   <div class='sold-out'>
                     <span>Sold Out!!</span>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,55 +127,55 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @products != blank? %>
+        <li class='list'>
+            <%= link_to "#" do %> 
+              <div class='item-img-content'>
+                <%= image_tag "item-sample.png", class: "item-img" %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= "商品名" %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= "販売価格" %>円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+          <% end %> 
+        </li>
+        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% else %>
+        <%# 商品がない場合のダミー %>
+        <%# 商品がある場合は表示されないようにしましょう %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+          <% end %>
+        </li>
+        <%# //商品がある場合は表示されないようにしましょう %>
+        <%# /商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -141,7 +141,7 @@
                 </div>
                 <div class='item-info'>
                   <h3 class='item-name'>
-                    <%=  "商品名" %>
+                    <%= product.name %>
                   </h3>
                   <div class='item-price'>
                     <span><%= "販売価格" %>円<br>(税込み)</span>


### PR DESCRIPTION
# What

Topページ内の商品一覧表示機能の実装

# Why

Topページ内に出品済み商品情報(商品名、販売価格、商品画像)を表示させる為

# 実装映像
https://gyazo.com/88c43dff72c98c7c90ab6ae015b82089

# 実装の条件
- 画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
- 出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、「sold out」の文字が表示されるようになっていること
- ログアウトした状態でも商品一覧ページを見ることができること

# 補足情報
「売却済みの商品は、『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能実装後に実装すること（商品購入機能実装前に商品一覧表示機能を実装する場合、コードレビュー時にこの機能は実装されていなくても良い。しかし、最終課題終了報告時に実装できていない場合、最終課題終了とはみなされない）。